### PR TITLE
Update to v1.8 of Jobe

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ years, running many millions of submissions. Jobe is also used by over 600 other
 CodeRunner sites around the world. It can be considered stable and secure,
 though it should be run only on a separate appropriately-firewalled server.
 
-With reference to the original API spec, onnly immediate-mode runs are
+With reference to the original API spec, only immediate-mode runs are
 supported, with run results being returned with the
 response to the POST of the run requests. Run results are not retained by
 the server (unless *run\_spec.debug* is true; see the API), so

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # JOBE
 
-Version: 1.7.0, 27 November 2022
+Version: 1.7.1, 15 May 2023
 
 
 Author: Richard Lobb, University of Canterbury, New Zealand
@@ -40,7 +40,7 @@ with only a few minor bug fixes and security refinements.
 
 ## Implementation status
 
-The current version of Jobe (Version 1.6, January 2019) implements
+The current version of Jobe (Version 1.7.1, May 2023) implements
 a subset of the originally documented API, sufficient for use by CodeRunner.
 It has been used for many years at the University of Canterbury for several
 years, running many millions of submissions. Jobe is also used by over 600 other
@@ -131,7 +131,7 @@ installed.
 
 ### Installing the necessary dependencies
 
-On Ubuntu-16.04 or 18.04, the commands to set up all the necessary web tools plus
+On Ubuntu-22.04, the commands to set up all the necessary web tools plus
 all currently-supported languages is the following:
 
     sudo apt-get install apache2 php libapache2-mod-php php-cli\
@@ -968,3 +968,15 @@ that results in multiple error messages when a python syntax check fails.
 
   1. Add several command-line arguments to make the testsubmit.py program more
      user-friendly.
+
+### 1/7/1 (15 May 2023)
+
+  1. Increase memory allocation for Python as jobs continue to grow in memory demand.
+
+  1. Add HTTP return code to the error message on invalid sourcefilename.
+
+  1. Ensure PHP 8.2 compatibility by allowing dynamic properties in the CodeIgniter core
+     and by adding property declarations to Jobe classes.
+
+  1. Increase the backoff from 1 sec to 5 secs when starting the sustained load testing.
+     Otherwise, the first test could fail.

--- a/README.md
+++ b/README.md
@@ -996,4 +996,3 @@ that results in multiple error messages when a python syntax check fails.
      with the host.
      Also include a --uninstall option.
 
-

--- a/README.md
+++ b/README.md
@@ -559,7 +559,7 @@ defined with an SQL command like
 	) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 You can turn off limit checking on a key-by-key basis by setting the *ignore_limits*
-to FALSE in the *keys* table.
+to TRUE (1) in the *keys* table.
 
 You should read the REST-server plugin documentation and the file
 *application/config/rest.php* for other features available.

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # JOBE
 
-Version: 1.7.1, 15 May 2023
+Version: 1.8.0, 9 October 2023
 
 
 Author: Richard Lobb, University of Canterbury, New Zealand
 
-Contributors: Tim Hunt, Fedor Lyanguzov, Kai-Cheung Leung
+Contributors: Tim Hunt, Fedor Lyanguzov, Kai-Cheung Leung, Marcus Klang
 
 ## Introduction
 
@@ -1010,4 +1010,16 @@ that results in multiple error messages when a python syntax check fails.
      a workaround for JobeInABox installs on systems running nginx, which resulted in a UID conflict
      with the host.
      Also include a --uninstall option.
+
+### 1.8.0 (9 October 2023)
+
+  1. Add various tuning parameters for Java to config file. Thanks Marcus Klang.
+
+  1. Ensure that install updates runguard config to allow for a large number of
+     Jobe users (> 20). Thanks Marcus Klang.
+
+  1. Add a main_class parameter to Java task. Thanks Peter Seibel.
+
+  1. Increase default per-run memory allocation from 200 MB to 400 MB. Needed for
+     NodeJS in particular but everything is getting greedier.
 

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ on it! **CAVEAT EMPTOR!**
 NOTE: a video walkthrough of the process of setting up a Jobe server
 on a DigitalOcean droplet is [here](https://www.youtube.com/watch?v=dGpnQpLnERw).
 
-Installation on Ubuntu 18.04 systems should be
+Installation on Ubuntu 22.04 systems should be
 straightforward but installation on other flavours of Linux or on systems
 with non-standard configurations may require
 Linux administrator skills.
@@ -111,13 +111,14 @@ Linux administrator skills.
 An alternative approach, and probably the simplest way to get up and running,
 is to use the [JobeInABox](https://hub.docker.com/r/trampgeek/jobeinabox/)
 Docker image, which should be runnable with a single terminal command
-on any Linux system that has
-docker installed. Thanks to David Bowes for the initial work on this.
+on any Linux system that has docker installed. Thanks to David Bowes for the initial work on this.
 Please be aware that while this Docker image has been around for a couple of years
-and no significant issues have been reported the developer has not himself
-used it in a production environment. Feedback is welcomed. The steps to fire
-up a Jobe Server on Digital Ocean using JobeInAbox are given below in section
+the developer has not himself used it in a production environment. Feedback is welcomed.
+The steps to fire up a Jobe Server on Digital Ocean using JobeInAbox are given below in section
 *Setting up a JobeInAbox Digital Ocean server*.
+
+However, for security and performance reasons it it *strongly* recommended to run
+Jobe on a dedicated server, even when running it in a container. 
 
 Jobe runs only on Linux, which must have the Apache web server
 installed and running. PHP must have been compiled with the System V
@@ -247,11 +248,12 @@ to use Version 3.3 or later.
 
 For people wanting to get a Jobe server up in hurry, the following is
 probably the simplest approach. This uses a minimal Digital Ocean virtual machine,
-costing just $US5.00 per month, to run the Docker *JobeInAbox* image.
+to run the Docker *JobeInAbox* image; you should increase memory and core for
+production servers. 
 Other cloud servers, such as Amazon ECS, can of course also be used.
 
  1. Set yourself up with an account on [Digital Ocean](https://cloud.digitalocean.com).
- 2. Create new Droplet: Ubuntu 20.04. x64, minimal config ($5 per month; 1GB CPI, 25GB disk)
+ 2. Create new Droplet: Ubuntu 22.04. x64, minimal config (1GB CPI, 25GB disk)
  3. Connect to the server with an SSH client.
  4. Install docker (see https://phoenixnap.com/kb/how-to-install-docker-on-ubuntu-18-04):
     sudo apt update; sudo apt install docker.io
@@ -969,7 +971,7 @@ that results in multiple error messages when a python syntax check fails.
   1. Add several command-line arguments to make the testsubmit.py program more
      user-friendly.
 
-### 1/7/1 (15 May 2023)
+### 1.7.1 (15 May 2023)
 
   1. Increase memory allocation for Python as jobs continue to grow in memory demand.
 
@@ -980,3 +982,18 @@ that results in multiple error messages when a python syntax check fails.
 
   1. Increase the backoff from 1 sec to 5 secs when starting the sustained load testing.
      Otherwise, the first test could fail.
+
+### 1.7.2 (4 June 2023)
+
+  1. Fix long-standing bug that always applied a compile parameter setting if this was
+    greater than the requested value, even when it wasn't a compile. Hopefully won't
+    break anyone's code (they'd have to have been using very low parameter values).
+
+  1. Bug fix: purge fails if num_jobe_users has been reduced in the config file since the install was run.
+
+  1. Upgrade install to include option to set range of UIDs for Jobe and workers. This should provide
+     a workaround for JobeInABox installs on systems running nginx, which resulted in a UID conflict
+     with the host.
+     Also include a --uninstall option.
+
+

--- a/README.md
+++ b/README.md
@@ -583,7 +583,7 @@ before the job is aborted
  1. streamsize (2): the maximum number of megabytes of standard output before the
 job is aborted.
  1. cputime (5): the maximum number of seconds of CPU time before the job is aborted
- 1. memorylimit (usually 200 but 600 for Python3):
+ 1. memorylimit (default 400 but raised for some languages, e.g. 1000 for Python3):
 the maximum number of megabytes of memory the task can consume. This value is
 used to set the Linux RLIMIT_STACK, RLIMIT_DATA and
 RLIMIT_AS via the *setrlimit* system call. If the value is exceeded the job

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ The steps to fire up a Jobe Server on Digital Ocean using JobeInAbox are given b
 *Setting up a JobeInAbox Digital Ocean server*.
 
 However, for security and performance reasons it it *strongly* recommended to run
-Jobe on a dedicated server, even when running it in a container. 
+Jobe on a dedicated server, even when running it in a container.
 
 Jobe runs only on Linux, which must have the Apache web server
 installed and running. PHP must have been compiled with the System V
@@ -199,6 +199,21 @@ set-up a jobe-sudoers file in /etc/sudoers.d that allows the web server
 to execute the runguard program as root and to kill any residual jobe
 processes from the run.
 
+Before running the install script, you might wish to edit the file
+
+    /var/www/html/jobe/application/config/config.php
+
+Find the line
+
+    $config['jobe_max_users'] = 8;
+
+and decide if that value, which sets the maximum number of jobs that can be run
+at once, is appropriate for your hardware set up. A rule of thumb is to set this
+to the number of cores on your machine, but if you plan on running lots of
+partially-I/O-bound jobs, you could consider larger numbers.
+
+Having set that value to your satisfaction:
+
     cd WEBROOT/jobe
     sudo ./install
 
@@ -249,7 +264,7 @@ to use Version 3.3 or later.
 For people wanting to get a Jobe server up in hurry, the following is
 probably the simplest approach. This uses a minimal Digital Ocean virtual machine,
 to run the Docker *JobeInAbox* image; you should increase memory and core for
-production servers. 
+production servers.
 Other cloud servers, such as Amazon ECS, can of course also be used.
 
  1. Set yourself up with an account on [Digital Ocean](https://cloud.digitalocean.com).

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Otherwise, they're taken as 8-bit character streams; characters below '\x20'
 (the space
 character) and above '\x7E' are replaced by C-style hexadecimal encodings
 (e.g. '\x8E') except for newlines which are passed through directly, and
-tabls and returns which are replaced with '\t' and '\r' respectively.
+tabs and returns which are replaced with '\t' and '\r' respectively.
 
 If Jobe is to correctly handle utf-8 output from programs, the Apache LANG
 environment variable must be set to a UTF-8 compatible value. See

--- a/application/config/config.php
+++ b/application/config/config.php
@@ -551,42 +551,42 @@ $config['python3_version'] = 'python3'; # /usr/bin/<python3_version> is the pyth
 
 /*
 |--------------------------------------------------------------------------
-| Jobe parameters: CPU pinning for jobs
+| Jobe parameters: CPU pinning for jobs  [Thanks Marcus Klang]
 |--------------------------------------------------------------------------
 |
 | This section of the config file controls processor affinity, i.e. pinning
 | runguard tasks to a particular CPU core.
 |
-| The way task are pinned is to use the jobe user id modulo the number of 
+| The way task are pinned is to use the jobe user id modulo the number of
 | cores. Under a load which requires more compute than is available
 | this yields linear slowdown for each job. Assigning jobs to a specific
 | core yields more predictable behaviour during extreme overallocation.
-| This is more significant with machines that have multi-socket CPUs 
-| which can have larger memory/cache penalites when tasks are transferred 
+| This is more significant with machines that have multi-socket CPUs
+| which can have larger memory/cache penalites when tasks are transferred
 | between cores.
 |
-| Consider setting jobe_max_users to be a multiple of num_cores, otherwise 
+| Consider setting jobe_max_users to be a multiple of num_cores, otherwise
 | there will be imbalance under 100% job allocation.
 |
-| Enabling this option restricts each job to a singular core, regardless 
-| of number of spawned threads. Multiple threads will work fine but they 
+| Enabling this option restricts each job to a singular core, regardless
+| of number of spawned threads. Multiple threads will work fine but they
 | cannot run perfectly concurrent, a context switch must occur.
 */
-$config['cpu_pinning_enabled'] = FALSE; 
-$config['cpu_pinning_num_cores'] = 16; // Update to number of server cores
+$config['cpu_pinning_enabled'] = false;
+$config['cpu_pinning_num_cores'] = 8; // Update to number of server cores
 
 /*
 |--------------------------------------------------------------------------
-| Jobe parameters: Extra Java/Javac arguments
+| Jobe parameters: Extra Java/Javac arguments [Thanks Marcus Klang]
 |--------------------------------------------------------------------------
 |
 | This section of the config file adds extra flags to java and javac
 |
-| Provided examples tells java/javac that there is only 1 core, which 
-| reduces the number of spawned threads when compiling. This option can be 
+| Provided examples tells java/javac that there is only 1 core, which
+| reduces the number of spawned threads when compiling. This option can be
 | used to provide a better experience when many users are using jobe.
 */
-$config['javac_extraflags'] = ''; //'-J-XX:ActiveProcessorCount=1'; 
+$config['javac_extraflags'] = ''; //'-J-XX:ActiveProcessorCount=1';
 $config['java_extraflags'] = ''; //'-XX:ActiveProcessorCount=1';
 
 /* End of file config.php */

--- a/application/config/config.php
+++ b/application/config/config.php
@@ -549,5 +549,31 @@ $config['python3_version'] = 'python3'; # /usr/bin/<python3_version> is the pyth
 // might be hidden away in a systemd-private directory, depending on your Linux
 // version).
 
+/*
+|--------------------------------------------------------------------------
+| Jobe parameters: CPU pinning for jobs
+|--------------------------------------------------------------------------
+|
+| This section of the config file controls processor affinity, i.e. pinning
+| runguard tasks to a particular CPU core.
+|
+| The way task are pinned is to use the jobe user id modulo the number of 
+| cores. Under a load which requires more compute than is available
+| this yields linear slowdown for each job. Assigning jobs to a specific
+| core yields more predictable behaviour during extreme overallocation.
+| This is more significant with machines that have multi-socket CPUs 
+| which can have larger memory/cache penalites when tasks are transferred 
+| between cores.
+|
+| Consider setting jobe_max_users to be a multiple of num_cores, otherwise 
+| there will be imbalance under 100% job allocation.
+|
+| Enabling this option restricts each job to a singular core, regardless 
+| of number of spawned threads. Multiple threads will work fine but they 
+| cannot run perfectly concurrent, a context switch must occur.
+*/
+$config['cpu_pinning_enabled'] = FALSE; 
+$config['cpu_pinning_num_cores'] = 16; // Update to number of server cores
+
 /* End of file config.php */
 /* Location: ./application/config/config.php */

--- a/application/config/config.php
+++ b/application/config/config.php
@@ -542,7 +542,7 @@ $config['jobe_max_users'] = 8;
 $config['jobe_wait_timeout'] = 10;  // Max number of secs to wait for a free Jobe user.
 $config['cputime_upper_limit_secs'] = 50;
 $config['clean_up_path'] = '/tmp;/var/tmp;/var/crash;/run/lock;/var/lock';
-$config['debugging'] = FALSE;
+$config['debugging'] = false;
 $config['python3_version'] = 'python3'; # /usr/bin/<python3_version> is the python to run
 // NB: if you modify the python3_version configuration you will also need to
 // reboot the server or delete the file /tmp/jobe_language_cache_file (which

--- a/application/config/config.php
+++ b/application/config/config.php
@@ -575,5 +575,19 @@ $config['python3_version'] = 'python3'; # /usr/bin/<python3_version> is the pyth
 $config['cpu_pinning_enabled'] = FALSE; 
 $config['cpu_pinning_num_cores'] = 16; // Update to number of server cores
 
+/*
+|--------------------------------------------------------------------------
+| Jobe parameters: Extra Java/Javac arguments
+|--------------------------------------------------------------------------
+|
+| This section of the config file adds extra flags to java and javac
+|
+| Provided examples tells java/javac that there is only 1 core, which 
+| reduces the number of spawned threads when compiling. This option can be 
+| used to provide a better experience when many users are using jobe.
+*/
+$config['javac_extraflags'] = ''; //'-J-XX:ActiveProcessorCount=1'; 
+$config['java_extraflags'] = ''; //'-XX:ActiveProcessorCount=1';
+
 /* End of file config.php */
 /* Location: ./application/config/config.php */

--- a/application/controllers/Restapi.php
+++ b/application/controllers/Restapi.php
@@ -153,7 +153,7 @@ class Restapi extends REST_Controller {
             $this->error('runs_post: invalid run specification', 400);
         }
         if (isset($run['sourcefilename']) && !self::is_valid_source_filename($run['sourcefilename'])) {
-            $this->error('runs_post: invalid sourcefilename');
+            $this->error('runs_post: invalid sourcefilename', 400);
         }
 
         // REST_Controller has called to_array on the JSON decoded

--- a/application/libraries/LanguageTask.php
+++ b/application/libraries/LanguageTask.php
@@ -40,7 +40,7 @@ abstract class Task {
         'disklimit'     => 20,      // MB (for normal files)
         'streamsize'    => 2,       // MB (for stdout/stderr)
         'cputime'       => 5,       // secs
-        'memorylimit'   => 200,     // MB
+        'memorylimit'   => 400,     // MB
         'numprocs'      => 30,
         'compileargs'   => array(),
         'linkargs'      => array(),

--- a/application/libraries/LanguageTask.php
+++ b/application/libraries/LanguageTask.php
@@ -276,12 +276,22 @@ abstract class Task {
      * from running the given command.
      */
     public function run_in_sandbox($wrappedCmd, $iscompile=true, $stdin=null) {
+        global $CI;
+
         $filesize = 1000 * $this->getParam('disklimit', $iscompile); // MB -> kB
         $streamsize = 1000 * $this->getParam('streamsize', $iscompile); // MB -> kB
         $memsize = 1000 * $this->getParam('memorylimit', $iscompile);
         $cputime = $this->getParam('cputime', $iscompile);
         $killtime = 2 * $cputime; // Kill the job after twice the allowed cpu time
         $numProcs = $this->getParam('numprocs', $iscompile) + 1; // The + 1 allows for the sh command below.
+
+        // CPU pinning - only active if enabled 
+        $sandboxCpuPinning = array();
+        if($CI->config->item('cpu_pinning_enabled') == TRUE) {
+            $taskset_core_id = intval($this->userId) % intval($CI->config->item('cpu_pinning_num_cores'));
+            $sandboxCpuPinning = array("taskset --cpu-list " . $taskset_core_id);
+        }
+
         $sandboxCommandBits = array(
                 "sudo " . dirname(__FILE__)  . "/../../runguard/runguard",
                 "--user={$this->user}",
@@ -292,6 +302,9 @@ abstract class Task {
                 "--nproc=$numProcs",       // Max num processes/threads for this *user*
                 "--no-core",
                 "--streamsize=$streamsize");   // Max stdout/stderr sizes
+
+        // Prepend CPU pinning command if enabled
+        $sandboxCommandBits = array_merge($sandboxCpuPinning, $sandboxCommandBits);
 
         if ($memsize != 0) {  // Special case: Matlab won't run with a memsize set. TODO: WHY NOT!
             $sandboxCommandBits[] = "--memsize=$memsize";

--- a/application/libraries/LanguageTask.php
+++ b/application/libraries/LanguageTask.php
@@ -348,10 +348,8 @@ abstract class Task {
         } else {
             $param = $default;
         }
-        // ** BUG ** The min_params_compile value is being applied even if
-        // this is not a compile. I'm reluctant to fix, however, as it may
-        // break existing questions with inappropriately low resource settings.
-        if ($param != 0 && array_key_exists($key, $this->min_params_compile) &&
+
+        if ($iscompile && $param != 0 && array_key_exists($key, $this->min_params_compile) &&
                 $this->min_params_compile[$key] > $param) {
             $param = $this->min_params_compile[$key];
         }

--- a/application/libraries/LanguageTask.php
+++ b/application/libraries/LanguageTask.php
@@ -60,22 +60,24 @@ abstract class Task {
         'numprocs'      => 5        // processes
     );
 
-    public $id;             // The task id - use the workdir basename
-    public $input;          // Stdin for this task
-    public $sourceFileName; // The name to give the source file
-    public $params;         // Request parameters
+    public string $id;             // The task id - use the workdir basename
+    public string $input;          // Stdin for this task
+    public string $sourceFileName; // The name to give the source file
+    public string $executableFileName;  // The name of the compiled (if necessary) executable
+    public array $params;          // Request parameters
 
-    public $userId = null;  // The user id (number counting from 0).
-    public $user;           // The corresponding user name (e.g. jobe01).
+    public ?int $userId = null;     // The user id (number counting from 0).
+    public ?string $user;           // The corresponding user name (e.g. jobe01).
 
-    public $cmpinfo = '';   // Output from compilation
-    public $time = 0;       // Execution time (secs)
-    public $memory = 0;     // Memory used (MB)
-    public $signal = 0;
-    public $stdout = '';    // Output from execution
-    public $stderr = '';
-    public $result = Task::RESULT_INTERNAL_ERR;  // Should get overwritten
-    public $workdir = '';   // The temporary working directory created in constructor
+    public string $cmpinfo = '';   // Output from compilation
+    public float $time = 0;       // Execution time (secs)
+    public int $memory = 0;     // Memory used (MB)
+    public int $signal = 0;
+    public string $stdout = '';    // Output from execution
+    public string $stderr = '';
+    public int $result = Task::RESULT_INTERNAL_ERR;  // Should get overwritten
+    public ?string $workdir = '';   // The temporary working directory created in constructor
+
 
     // ************************************************
     //   MAIN METHODS THAT HANDLE THE FLOW OF ONE JOB

--- a/application/libraries/java_task.php
+++ b/application/libraries/java_task.php
@@ -13,6 +13,8 @@
 require_once('application/libraries/LanguageTask.php');
 
 class Java_Task extends Task {
+    public string $mainClassName;
+    
     public function __construct($filename, $input, $params) {
         $params['memorylimit'] = 0;    // Disregard memory limit - let JVM manage memory
         $this->default_params['numprocs'] = 256;     // Java 8 wants lots of processes

--- a/application/libraries/java_task.php
+++ b/application/libraries/java_task.php
@@ -24,7 +24,7 @@ class Java_Task extends Task {
              "-Xss8m",
              "-Xmx200m"
         );
-        $this->default_params['main_class'] = FALSE;
+        $this->default_params['main_class'] = null;
 
         if (isset($params['numprocs']) && $params['numprocs'] < 256) {
             $params['numprocs'] = 256;  // Minimum for Java 8 JVM

--- a/application/libraries/java_task.php
+++ b/application/libraries/java_task.php
@@ -24,6 +24,7 @@ class Java_Task extends Task {
              "-Xss8m",
              "-Xmx200m"
         );
+        $this->default_params['main_class'] = FALSE;
 
         if (isset($params['numprocs']) && $params['numprocs'] < 256) {
             $params['numprocs'] = 256;  // Minimum for Java 8 JVM
@@ -74,7 +75,7 @@ class Java_Task extends Task {
 
 
     public function getTargetFile() {
-        return $this->mainClassName;
+        return $this->getParam('main_class') ?? $this->mainClassName;
     }
 
 

--- a/application/libraries/python3_task.php
+++ b/application/libraries/python3_task.php
@@ -22,7 +22,7 @@ class Python3_Task extends Task {
     // on import.
     public function __construct($filename, $input, $params) {
         parent::__construct($filename, $input, $params);
-        $this->default_params['memorylimit'] = 600; // Need more for numpy
+        $this->default_params['memorylimit'] = 1000; // Nnumpy+matplotlib is getting greedier.
         $this->default_params['interpreterargs'] = array('-BE');
     }
 

--- a/application/libraries/resultobject.php
+++ b/application/libraries/resultobject.php
@@ -13,6 +13,12 @@
 
 class ResultObject {
 
+    public ?string $run_id;
+    public int $outcome;
+    public string $cmpinfo;
+    public string $stdout;
+    public string $stderr;
+
     public function __construct(
             $run_id,
             $outcome,

--- a/install
+++ b/install
@@ -154,6 +154,18 @@ def do_purge(install_dir):
     do_command('rm -rf {}/files'.format(install_dir), ignore_errors=True)
     do_command('rm -rf ' + FILE_CACHE_BASE + '/*', ignore_errors=True)
 
+def update_runguard_config(install_dir, num_jobe_users):
+    # Make sure the number of valid users are matching our num jobe users
+    print("Settig up runguard config")
+    runguard_users = ["domjudge", "jobe"] + ['jobe{:02d}'.format(i) for i in range(num_jobe_users)]
+    with open(os.path.join(install_dir, "runguard/runguard-config.h"), "r") as runguard_config_in:
+        runguard_config = runguard_config_in.read()
+
+    runguard_valid_users = ",".join(runguard_users)
+
+    runguard_config = re.sub("#define\s+VALID_USERS[^\n]+", '#define VALID_USERS "' + runguard_valid_users + '"', runguard_config)
+    with open(os.path.join(install_dir, "runguard/runguard-config.h"), "w") as runguard_config_out:
+        runguard_config_out.write(runguard_config)
 
 def make_workers(num_jobe_users, max_uid):
     """Make the Jobe worker users"""
@@ -178,6 +190,9 @@ def create_jobe_user_and_files(install_dir, webserver_user, max_uid):
     make_directory('/home/jobe/files', 'jobe', webserver_user)
     print("Setting up Jobe log directory (/var/log/jobe)")
     make_directory('/var/log/jobe', 'jobe', webserver_user)
+
+
+
 
 
 def process_command_line_args():
@@ -233,6 +248,7 @@ def main():
         make_directory(FILE_CACHE_BASE, 'jobe', webserver_user)
 
         print("Building runguard")
+        update_runguard_config(install_dir, num_jobe_users)
         make_runguard(install_dir)
         
         make_sudoers(install_dir, webserver_user, num_jobe_users)

--- a/install
+++ b/install
@@ -122,10 +122,14 @@ def make_directory(dirpath, owner, group, permissions=771):
     do_command('chown {0}:{1} {2}; chmod {3} {2}'.format(owner, group, dirpath, permissions))
 
 
-def do_purge(install_dir, num_runners):
+def do_purge(install_dir):
     '''Purge existing users and extra files set up by a previous install'''
-    for i in range(num_runners):
-        do_command('userdel jobe{:02d}'.format(i), ignore_errors=True)
+    with open('/etc/passwd') as infile:
+        lines = infile.read().splitlines()
+
+    jobe_users = [line.split(':')[0] for line in lines if re.match(r'jobe\d\d', line)]
+    for jobe_user in jobe_users:
+        do_command(f'userdel {jobe_user}', ignore_errors=True)
 
     do_command('userdel jobe', ignore_errors=True)
     do_command('groupdel jobe', ignore_errors=True)
@@ -133,7 +137,6 @@ def do_purge(install_dir, num_runners):
     do_command('rm -rf /var/log/jobe')
     do_command('rm -rf {}/files'.format(install_dir), ignore_errors=True)
     do_command('rm -rf ' + FILE_CACHE_BASE + '/*', ignore_errors=True)
-
 
 def main():
     if len(sys.argv) > 2 or (len(sys.argv) > 1 and sys.argv[1] != '--purge'):
@@ -157,7 +160,7 @@ def main():
             num_jobe_users = int(get_config('jobe_max_users', install_dir))
             if purging:
                 print('Purging all prior jobe users and files')
-                do_purge(install_dir, num_jobe_users)
+                do_purge(install_dir)
 
             print('Configuring for', num_jobe_users, 'simultaneous job runs')
             webserver_user = get_webserver()

--- a/install
+++ b/install
@@ -11,6 +11,10 @@ import os
 import subprocess
 import re
 import sys
+import argparse
+
+class LoginDefsException (Exception):
+    pass
 
 
 JOBE_DIRS = ['/var/www/jobe', '/var/www/html/jobe']
@@ -22,7 +26,7 @@ def get_config(param_name, install_dir):
        An exception occurs if either the file or the required parameter
        is not found.
     '''
-    with open('{}/application/config/config.php'.format(install_dir)) as config:
+    with open(f'{install_dir}/application/config/config.php') as config:
         lines = config.readlines()
     patterns = [
         r" *\$config\[ *'{}' *\] *= *\"([^\"]+)\";.*\n".format(param_name), # Double-quoted string
@@ -38,6 +42,7 @@ def get_config(param_name, install_dir):
 
 
 def fail():
+    """We're dead, Fred"""
     print("Install failed")
     sys.exit(1);
 
@@ -53,7 +58,9 @@ def get_webserver():
     candidates = names.intersection(set(['apache', 'www-data']))
     if len(candidates) != 1:
         raise Exception("Couldn't determine web-server user id. Is the web server running?")
-    return list(candidates)[0]
+    webserver_user = list(candidates)[0]
+    print("Web server is", webserver_user)
+    return webserver_user
 
 
 def do_command(cmd, ignore_errors=False):
@@ -98,7 +105,7 @@ def make_sudoers(install_dir, webserver_user, num_jobe_users):
             sudoers.write('{} ALL=(root) NOPASSWD: {}\n'.format(webserver_user, cmd))
 
 
-def make_user(username, comment, make_home_dir=False, group='jobe'):
+def make_user(username, comment, make_home_dir=False, group='jobe', uid=None):
     ''' Check if user exists. If not, add the named user with the given comment.
         Make a home directory only if make_home_dir is true.
     '''
@@ -107,11 +114,9 @@ def make_user(username, comment, make_home_dir=False, group='jobe'):
         print(username, 'already exists')
     except:
         opt = '--home /home/jobe -m' if make_home_dir else ' -M'
-        if group is None:
-            group_opt = ''
-        else:
-            group_opt = ' -g ' + group
-        do_command('useradd -r {} -s "/bin/false"{} -c "{}" {}'.format(opt, group_opt, comment, username))
+        group_opt = '' if group is None else f" -g {group}"
+        uid_opt = '' if uid is None else f" -u {uid}"
+        do_command(f'useradd -r {opt} -s "/bin/false"{group_opt}{uid_opt} -c "{comment}" {username}')
 
 
 def make_directory(dirpath, owner, group, permissions=771):
@@ -120,6 +125,17 @@ def make_directory(dirpath, owner, group, permissions=771):
     if not os.path.exists(dirpath):
         os.makedirs(dirpath)
     do_command('chown {0}:{1} {2}; chmod {3} {2}'.format(owner, group, dirpath, permissions))
+
+
+def make_runguard(install_dir):
+    """Make the runguard application"""
+    runguard_commands = [
+        "cd {0}".format(install_dir + '/runguard'),
+        "gcc -o runguard runguard.c", # TODO Add -lcgroups  if using cgroups
+        "chmod 700 runguard"
+    ]
+    cmd = ';'.join(runguard_commands)
+    do_command(cmd)
 
 
 def do_purge(install_dir):
@@ -132,19 +148,59 @@ def do_purge(install_dir):
         do_command(f'userdel {jobe_user}', ignore_errors=True)
 
     do_command('userdel jobe', ignore_errors=True)
-    do_command('groupdel jobe', ignore_errors=True)
+    #do_command('groupdel jobe', ignore_errors=True)
     do_command('rm -rf /home/jobe')
     do_command('rm -rf /var/log/jobe')
     do_command('rm -rf {}/files'.format(install_dir), ignore_errors=True)
     do_command('rm -rf ' + FILE_CACHE_BASE + '/*', ignore_errors=True)
 
+
+def make_workers(num_jobe_users, max_uid):
+    """Make the Jobe worker users"""
+    print(f"Making {num_jobe_users} Jobe workers")
+    uid = None if max_uid is None else max_uid - 1 # First uid is one less than max_uid (used by Jobe)
+    for i in range(num_jobe_users):
+        username = 'jobe{:02d}'.format(i)
+        make_user(username, 'Jobe server task runner', uid=uid)
+        if uid is not None:
+            uid -= 1
+
+
+def create_jobe_user_and_files(install_dir, webserver_user, max_uid):
+    """Create the user jobe and set up the home directory for runs"""
+    print("Making user jobe")
+    make_user('jobe', 'Jobe user. Provides home for runs and files.', True, None, max_uid)
+    # make sure webuser can reach /home/jobe/runs despite its not being in jobe group
+    do_command("chmod 751 /home/jobe")
+    print("Setting up Jobe runs directory (/home/jobe/runs)")
+    make_directory('/home/jobe/runs', 'jobe', webserver_user)
+    print("Setting up Jobe files directory (/home/jobe/files)")
+    make_directory('/home/jobe/files', 'jobe', webserver_user)
+    print("Setting up Jobe log directory (/var/log/jobe)")
+    make_directory('/var/log/jobe', 'jobe', webserver_user)
+
+
+def process_command_line_args():
+    """Command line argument handler."""
+    def max_uid(s):
+        max_uid = int(s)
+        if max_uid < 200 or max_uid > 998:
+            raise argparse.ArgumentTypeError("max_uid must be in the range 200 to 998")
+        return max_uid
+    
+    parser = argparse.ArgumentParser(description='Jobe installer')
+    parser.add_argument('--purge', action="store_true", help='Purge prior Jobe settings and files before installing')
+    parser.add_argument('--uninstall', action="store_true", help='Uninstall jobe')
+    parser.add_argument('--max_uid', action="store", type=max_uid, default=None,
+                        help="Set the maximum system UID to be used by Jobe and its workers. For use in containers only.")
+    args = parser.parse_args(sys.argv[1:])
+    return args
+
+
 def main():
-    if len(sys.argv) > 2 or (len(sys.argv) > 1 and sys.argv[1] != '--purge'):
-        print("Usage: install [--purge]")
-        sys.exit(0)
+    """Every home should have one."""
 
-    purging = len(sys.argv) == 2
-
+    args = process_command_line_args()
     install_dir = os.getcwd()
     if install_dir not in JOBE_DIRS:
         print("WARNING: Jobe appears not to have been installed in /var/www")
@@ -153,60 +209,44 @@ def main():
     if subprocess.check_output('whoami', shell=True) != b'root\n':
             print("****This script must be run by root*****")
             fail()
-    else:
+
+    try:
+        if args.purge or args.uninstall:
+            print('Purging all prior jobe users and files')
+            do_purge(install_dir)
+        if args.uninstall:
+            print("Jobe has been uninstalled")
+            sys.exit(0)
+
+        check_php_version()
+        webserver_user = get_webserver()
+
+        # Ensure install directory subtree owned by webuser and not readable by others
+        do_command('chown -R {0}:{0} {1}'.format(webserver_user, install_dir))
+        do_command('chmod -R o-rwx,g+w {}'.format(install_dir))
+
+        num_jobe_users = int(get_config('jobe_max_users', install_dir))
+        create_jobe_user_and_files(install_dir, webserver_user, args.max_uid)
+        make_workers(num_jobe_users, args.max_uid)
+
+        print("Setting up file cache")
+        make_directory(FILE_CACHE_BASE, 'jobe', webserver_user)
+
+        print("Building runguard")
+        make_runguard(install_dir)
+        
+        make_sudoers(install_dir, webserver_user, num_jobe_users)
         try:
-            check_php_version()
+            os.remove(LANGUAGE_CACHE_FILE)
+        except:
+            pass
 
-            num_jobe_users = int(get_config('jobe_max_users', install_dir))
-            if purging:
-                print('Purging all prior jobe users and files')
-                do_purge(install_dir)
+        print("Jobe installation complete")
 
-            print('Configuring for', num_jobe_users, 'simultaneous job runs')
-            webserver_user = get_webserver()
-            print("Web server is", webserver_user)
-            print("Make user jobe")
-            make_user('jobe', 'Jobe user. Provides home for runs and files.', True, None)
-            # make sure webuser can reach /home/jobe/runs despite its not being in jobe group
-            do_command("chmod 751 /home/jobe")
-            print("Setting up file cache")
-            make_directory(FILE_CACHE_BASE, 'jobe', webserver_user)
-
-            # Ensure install directory subtree owned by webuser and not readable by others
-            do_command('chown -R {0}:{0} {1}'.format(webserver_user, install_dir))
-            do_command('chmod -R o-rwx,g+w {}'.format(install_dir))
-
-            print("Making required job-runner users")
-            for i in range(num_jobe_users):
-                username = 'jobe{:02d}'.format(i)
-                make_user(username, 'Jobe server task runner')
-
-            print("Set up Jobe runs directory (/home/jobe/runs)")
-            make_directory('/home/jobe/runs', 'jobe', webserver_user)
-            print("Set up Jobe files directory (/home/jobe/files)")
-            make_directory('/home/jobe/files', 'jobe', webserver_user)
-            print("Set up Jobe log directory (/var/log/jobe)")
-            make_directory('/var/log/jobe', 'jobe', webserver_user)
-
-            print("Building runguard")
-            runguard_commands = [
-                "cd {0}".format(install_dir + '/runguard'),
-                "gcc -o runguard runguard.c", # TODO Add -lcgroups  if using cgroups
-                "chmod 700 runguard"
-            ]
-            cmd = ';'.join(runguard_commands)
-            do_command(cmd)
-
-            make_sudoers(install_dir, webserver_user, num_jobe_users)
-            try:
-                os.remove(LANGUAGE_CACHE_FILE)
-            except:
-                pass
-
-            print("Runguard installation complete")
-
-        except Exception as e:
-            print("Exception during install: " + str(e))
-            fail()
+    except Exception as e:
+        print("Exception during install: " + str(e))
+        fail()
 
 main()
+
+

--- a/install
+++ b/install
@@ -154,9 +154,10 @@ def do_purge(install_dir):
     do_command('rm -rf {}/files'.format(install_dir), ignore_errors=True)
     do_command('rm -rf ' + FILE_CACHE_BASE + '/*', ignore_errors=True)
 
+
 def update_runguard_config(install_dir, num_jobe_users):
     # Make sure the number of valid users are matching our num jobe users
-    print("Settig up runguard config")
+    print("Setting up runguard config")
     runguard_users = ["domjudge", "jobe"] + ['jobe{:02d}'.format(i) for i in range(num_jobe_users)]
     with open(os.path.join(install_dir, "runguard/runguard-config.h"), "r") as runguard_config_in:
         runguard_config = runguard_config_in.read()
@@ -166,6 +167,7 @@ def update_runguard_config(install_dir, num_jobe_users):
     runguard_config = re.sub("#define\s+VALID_USERS[^\n]+", '#define VALID_USERS "' + runguard_valid_users + '"', runguard_config)
     with open(os.path.join(install_dir, "runguard/runguard-config.h"), "w") as runguard_config_out:
         runguard_config_out.write(runguard_config)
+
 
 def make_workers(num_jobe_users, max_uid):
     """Make the Jobe worker users"""
@@ -192,9 +194,6 @@ def create_jobe_user_and_files(install_dir, webserver_user, max_uid):
     make_directory('/var/log/jobe', 'jobe', webserver_user)
 
 
-
-
-
 def process_command_line_args():
     """Command line argument handler."""
     def max_uid(s):
@@ -202,7 +201,7 @@ def process_command_line_args():
         if max_uid < 200 or max_uid > 998:
             raise argparse.ArgumentTypeError("max_uid must be in the range 200 to 998")
         return max_uid
-    
+
     parser = argparse.ArgumentParser(description='Jobe installer')
     parser.add_argument('--purge', action="store_true", help='Purge prior Jobe settings and files before installing')
     parser.add_argument('--uninstall', action="store_true", help='Uninstall jobe')
@@ -250,7 +249,7 @@ def main():
         print("Building runguard")
         update_runguard_config(install_dir, num_jobe_users)
         make_runguard(install_dir)
-        
+
         make_sudoers(install_dir, webserver_user, num_jobe_users)
         try:
             os.remove(LANGUAGE_CACHE_FILE)
@@ -264,5 +263,3 @@ def main():
         fail()
 
 main()
-
-

--- a/system/core/Controller.php
+++ b/system/core/Controller.php
@@ -49,7 +49,10 @@ defined('BASEPATH') OR exit('No direct script access allowed');
  * @author		EllisLab Dev Team
  * @link		https://codeigniter.com/user_guide/general/controllers.html
  */
-class CI_Controller {
+
+ #[\AllowDynamicProperties]
+ 
+ class CI_Controller {
 
 	/**
 	 * Reference to the CI singleton

--- a/system/core/Loader.php
+++ b/system/core/Loader.php
@@ -48,7 +48,11 @@ defined('BASEPATH') OR exit('No direct script access allowed');
  * @author		EllisLab Dev Team
  * @link		https://codeigniter.com/user_guide/libraries/loader.html
  */
-class CI_Loader {
+
+
+ #[\AllowDynamicProperties]
+ 
+ class CI_Loader {
 
 	// All these are set automatically. Don't mess with them.
 	/**

--- a/system/core/Router.php
+++ b/system/core/Router.php
@@ -48,7 +48,10 @@ defined('BASEPATH') OR exit('No direct script access allowed');
  * @author		EllisLab Dev Team
  * @link		https://codeigniter.com/user_guide/general/routing.html
  */
-class CI_Router {
+
+ #[\AllowDynamicProperties]
+ 
+ class CI_Router {
 
 	/**
 	 * CI_Config class object

--- a/system/core/URI.php
+++ b/system/core/URI.php
@@ -48,7 +48,11 @@ defined('BASEPATH') OR exit('No direct script access allowed');
  * @author		EllisLab Dev Team
  * @link		https://codeigniter.com/user_guide/libraries/uri.html
  */
-class CI_URI {
+
+
+ #[\AllowDynamicProperties]
+ 
+ class CI_URI {
 
 	/**
 	 * List of cached URI segments

--- a/system/database/DB_driver.php
+++ b/system/database/DB_driver.php
@@ -50,7 +50,10 @@ defined('BASEPATH') OR exit('No direct script access allowed');
  * @author		EllisLab Dev Team
  * @link		https://codeigniter.com/user_guide/database/
  */
-abstract class CI_DB_driver {
+
+ #[\AllowDynamicProperties]
+ 
+ abstract class CI_DB_driver {
 
 	/**
 	 * Data Source Name / Connect string

--- a/testsubmit.py
+++ b/testsubmit.py
@@ -1015,11 +1015,11 @@ def normal_testing(langs_to_run):
 
 def check_sustained_load(lang, starting_rate):
     """Check the achievable sustained load in the given language.
-       Starting at the given rate less 1 jobs/sec, send jobs at a steady rate
+       Starting at the given rate less 5 jobs/sec, send jobs at a steady rate
        over a 30 second time window, making sure all are successful. Increase the rate until
        a single failure occurs. Report the maximum achieved sustained rate.
     """
-    rate = max(1, int(starting_rate - 1))  # Jobs per sec
+    rate = max(1, int(starting_rate - 5))  # Jobs per sec
     best_rate = None
     job = [job for job in TEST_SET if job['language_id'] == lang][0]
 


### PR DESCRIPTION
This pulls in all changes between the original fork and v1.8 of Jobe.

v1.9 has a new runguard.c which caused enough issues to avoid it for now. Interestingly, later commits on v1 seem to have made optional some of those changes.

Suggest next bump be to v2.x.